### PR TITLE
Add support for Villagers to redstone teleports

### DIFF
--- a/src/main/java/com/onarandombox/MultiverseSignPortals/utils/PortalDetector.java
+++ b/src/main/java/com/onarandombox/MultiverseSignPortals/utils/PortalDetector.java
@@ -245,7 +245,7 @@ public class PortalDetector {
             List<LivingEntity> worldEntities = sign.getBlock().getWorld().getLivingEntities();
             List<LivingEntity> entitiesInRange = new ArrayList<LivingEntity>(worldEntities.size());
             for (LivingEntity entity : worldEntities) {
-                if ((type == ALL || type == ANIMALS) && (entity instanceof Animals || entity instanceof Squid)) {
+                if ((type == ALL || type == ANIMALS) && (entity instanceof Animals || entity instanceof Squid || entity instanceof Villager)) {
                     if (entity.getLocation().toVector().isInAABB(min, max)) {
                         plugin.log(Level.FINEST, "Found " + entity + " within range!");
                         entitiesInRange.add(entity);


### PR DESCRIPTION
Villagers are not affected by any SignPortal redstone teleports, even with `ALL`. This PR adds support for villagers, so that both `ANIMALS` and `ALL` redstone SignPortals affect villagers.

Although this PR was made via GitHub's edit file feature, I have tested this change locally in this environment:

* PaperSpigot 1.11 build 961, Java 8
* `This server is running Paper version git-Paper-961 (MC: 1.11) (Implementing API version 1.11-R0.1-SNAPSHOT)`
* Plugins (2): Multiverse-Core, Multiverse-SignPortals
* Multiverse-Core built from [latest `master` commit](https://github.com/Multiverse/Multiverse-Core/commit/c00847f173c2a20c2172c0cfa5c1d4d5d6449480)
* No compilation errors or run-time exception