### PR TITLE
Remove possible color codes from world name

### DIFF
--- a/src/main/java/com/onarandombox/MultiverseSignPortals/listeners/MVSPPlayerListener.java
+++ b/src/main/java/com/onarandombox/MultiverseSignPortals/listeners/MVSPPlayerListener.java
@@ -58,6 +58,7 @@ public class MVSPPlayerListener implements Listener {
             if (destString != null) {
                 this.plugin.log(Level.FINER, "Found a Multiverse Sign");
                 DestinationFactory df = this.plugin.getCore().getDestFactory();
+                destString = stripColor(destString);
                 MVDestination dest = df.getDestination(destString);
                 MVSPTravelAgent travelAgent = new MVSPTravelAgent(this.plugin.getCore(), dest, event.getPlayer());
                 travelAgent.setPortalEventTravelAgent(event);


### PR DESCRIPTION
I was attempting to make a sign portal to teleport to a world. The sign works fine, but with the default black text it is a little difficult to read. I attempted to change the color of the world with color codes, but as the color codes won't work in the world names, this doesn't work properly. I suggest that when teleporting to a given world, the code ignores the color codes and teleports to the raw_text name of the world.