### PR TITLE
Make Sure Version Info is Printed Correctly

### DIFF
--- a/src/main/java/com/onarandombox/MultiverseSignPortals/MultiverseSignPortals.java
+++ b/src/main/java/com/onarandombox/MultiverseSignPortals/MultiverseSignPortals.java
@@ -113,7 +113,7 @@ public class MultiverseSignPortals extends JavaPlugin implements MVPlugin {
     }
 
     public String getVersionInfo() {
-        return new StringBuilder("[Multiverse-SignPortals] Multiverse-SignPortals Version: ").append(this.getDescription().getVersion()).append('\n').toString();
+        return "[Multiverse-SignPortals] Multiverse-SignPortals Version: " + this.getDescription().getVersion() + System.lineSeparator();
     }
 
     // No longer using, use getVersionInfo instead.


### PR DESCRIPTION
This PR makes sure Multiverse-SignPortals' version info is printed correctly. The change needed was `\n` to `System.lineSeparator()`. The reason it was needed is that the Multiverse-Core Version Command splits on `System.lineSeparator()`.