### PR TITLE
Fix wrong detection of legacy signs

### DIFF
--- a/src/main/java/com/onarandombox/MultiverseSignPortals/utils/SignTools.java
+++ b/src/main/java/com/onarandombox/MultiverseSignPortals/utils/SignTools.java
@@ -13,7 +13,7 @@ public class SignTools {
     public static boolean isMVSign(String test, ChatColor color) {
         if (color == null) {
             test = ChatColor.stripColor(test);
-            return test.toLowerCase().matches("[multiverse]") || test.equalsIgnoreCase("[mv]");
+            return test.equalsIgnoreCase("[multiverse]") || test.equalsIgnoreCase("[mv]");
         }
         return test.equalsIgnoreCase(color + "[multiverse]") || test.equalsIgnoreCase(color + "[mv]");
     }


### PR DESCRIPTION
Currently the isMVSign check will return true if ANY of the characters in the word "multiverse" are present in the second line since this is doing a regex match, marking any sign with the characters m,u.l,t,i,v,e,r,s in the second line as a legacy sign, the check is now changed to an equalsIgnoreCase which is what is used everywhere else